### PR TITLE
Fix module imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@
     ]
     requires-python = ">=3.7"
     dependencies = [
+        "pyyaml",
         "mpi4py",
         "numpy",
         "netcdf4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
     requires = ["setuptools>=59.7", "wheel"]
     build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-    packages = ["rdy2cpl"]
-
 [project]
     name = "rdy2cpl"
     version = "0.1.0"


### PR DESCRIPTION
Some modules/packages (e.g. `rdy2cpl.model_spec`) cannot be imported when `rdy2cpl` is installed via setuptools:
```
> pip install git+https://github.com/uwefladrich/rdy2cpl.git
[...]
> python
>>> import rdy2cpl.model_spec
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'rdy2cpl.model_spec'
```