### PR TITLE
Add masks for runoff-mapper

### DIFF
--- a/rdy2cpl/grids/base/regular.py
+++ b/rdy2cpl/grids/base/regular.py
@@ -20,6 +20,7 @@ class RegularLatLonGrid:
         self.start_lat = start_lat
         self.transposed = transposed
         self.t = np.transpose if transposed else lambda x: x
+        self.mask = np.zeros(self.shape)
 
     @property
     def nlats(self):
@@ -91,10 +92,6 @@ class RegularLatLonGrid:
                 (self.nlons, 1),
             ).T
         )
-
-    @property
-    def mask(self):
-        return np.zeros(self.shape)
 
 
 class EquidistantLatLonGrid(RegularLatLonGrid):

--- a/rdy2cpl/model_spec/ecearth.py
+++ b/rdy2cpl/model_spec/ecearth.py
@@ -13,6 +13,10 @@ from rdy2cpl.grids.couple import CoupleGrid
 _log = logging.getLogger(__name__)
 
 
+def invert_mask(grid):
+    grid.mask = np.where(grid.mask == 1, 0, 1)
+
+
 def mask_box(grid, lats, lons):
     "Masks a box spanned by corners (lats[0], lons[0]) and (lats[1], lons[1])"
     grid.mask = np.where(

--- a/rdy2cpl/model_spec/ecearth.py
+++ b/rdy2cpl/model_spec/ecearth.py
@@ -115,7 +115,10 @@ _ece_grids = {
     "ILCM": _base_grid_factory(Tco159),
     "IOCH": _base_grid_factory(Tco319),
     "ILCH": _base_grid_factory(Tco319),
-    "RNFA": _base_grid_factory(N128, type_kwargs={"transposed": True}),
+    "RNFA": _base_grid_factory(N128, (), {"transposed": True}, ((rnfm_read_mask,),)),
+    "RNFO": _base_grid_factory(
+        N128, (), {"transposed": True}, ((rnfm_read_mask,), (invert_mask,))
+    ),
     "NOUM": _base_grid_factory(
         OrcaUGrid,
         ("domain_cfg.nc",),


### PR DESCRIPTION
Masks for the runoff-mapper are read from a NetCDF file. Also, two complementary grids (RNFA, RNFO) are needed for EC-Earth4.