### PR TITLE
List rdy2cpl package explicitely for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
     requires = ["setuptools>=59.7", "wheel"]
     build-backend = "setuptools.build_meta"
 
+[tools.setuptools]
+    packages = ["rdy2cpl"]
+
 [project]
     name = "rdy2cpl"
     version = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,6 @@ import setuptools
 
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(
+        packages=["rdy2cpl"],
+    )


### PR DESCRIPTION
Better to list the ``rdy2cpl`` package explicitely for setuptools because auto detection of packages (e.g. at ``pip install -e``) fails when additional directories are present. Since the latter is the case quite often during development (e.g. `work` or other dirs) it helps to avoid frequent extra steps when installing locally.