### PR TITLE
Revert !16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
     requires = ["setuptools>=59.7", "wheel"]
     build-backend = "setuptools.build_meta"
 
-[tools.setuptools]
-    packages = ["rdy2cpl"]
-
 [project]
     name = "rdy2cpl"
     version = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,4 @@ import setuptools
 
 
 if __name__ == "__main__":
-    setuptools.setup(
-        packages=["rdy2cpl"],
-    )
+    setuptools.setup()


### PR DESCRIPTION
Listing the `rdy2cpl` package explicitly causes problems when installing (at least when installing via `pip` from Github repo into a conda environment).

This reverts commit 034eb5ba84935f41f2ee517ffc4fefea8e1c66d1.