### PR TITLE
Allow centered/non-centered lons for EquidistantLatLonGrid

### DIFF
--- a/rdy2cpl/grids/base/regular.py
+++ b/rdy2cpl/grids/base/regular.py
@@ -95,10 +95,19 @@ class RegularLatLonGrid:
 
 
 class EquidistantLatLonGrid(RegularLatLonGrid):
-    def __init__(self, nlats, nlons, *, start_lat=-90, transposed=False):
+    def __init__(
+        self,
+        nlats,
+        nlons,
+        *,
+        start_lat=-90,
+        start_lon=0,
+        center_lons=False,
+        transposed=False,
+    ):
         super().__init__(
             equidistant(start_lat, -start_lat, nlats),
-            equidistant(0, 360, nlons, center_at_start=True),
+            equidistant(start_lon, start_lon + 360, nlons, center_at_start=center_lons),
             start_lat=start_lat,
             transposed=transposed,
         )


### PR DESCRIPTION
Allow longitudes of `EquidistantLatLonGrid`s to start at an arbitrary value and to be centred about the first longitude value or not.