### PR TITLE
Set reasonable defaults for srun options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ rdy2cpl.make_all:
 If the `couple_grid_spec` argument is used, the given YAML file is used to
 define the couple grids, instead of the built-in definitions.
 
-This task runs `r2c` through the SLURM `srun` command, with one node allocated
-per coupling weight file (indicated by `NWEIGHTS` below), as returned bu `r2c
--l`. Internally, it uses the command line
+This task runs `r2c` through the SLURM `srun` command, with one MPI task per
+coupling weight file (indicated by `NWEIGHTS` below), as returned by `r2c -l`.
+Additionally, it allocates cores for OpenMP parallelisation, if
+``OMP_NUM_THREAD`` is set. Internally, it uses the command line
 ```
-srun --nodes <NWEIGHTS> --ntasks <NWEIGHTS> --ntasks-per-node 1 \
+srun \
+  --ntasks <NWEIGHTS> --cpus-per-task <OMP_NUM_THREAD or OASIS_OMP_NUM_THREADS or 1> \
   r2c [--couple-grid-spec <COUPLE_GRID_SPEC_FILE>] <NAMCOUPLE_SPEC_FILE>
 ```
 The default `srun` options given above can be overwritten by using the

--- a/rdy2cpl/scriptengine_task.py
+++ b/rdy2cpl/scriptengine_task.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 import subprocess
 from dataclasses import asdict
@@ -63,13 +64,13 @@ else:
                 "srun_opts",
                 context,
                 default=[
-                    "--nodes", nweights,
                     "--ntasks", nweights,
-                    "--ntasks-per-node", 1,
+                    "--cpus-per-task",
+                    os.environ.get(
+                        "OMP_NUM_THREADS", os.environ.get("OASIS_OMP_NUM_THREADS", "1")
+                    ),
                 ],
             )
-
-            self.log_debug(f"Running r2c using {tmp_namcouple_file}")
 
             cmd = ["srun", *srun_opts, "r2c"]
             couple_grid_spec = self.getarg("couple_grid_spec", context, default=None)
@@ -77,6 +78,8 @@ else:
                 self.log_info(f"Reading couple grid spec from {couple_grid_spec}")
                 cmd.extend(["--couple-grid-spec", couple_grid_spec])
             cmd.append(tmp_namcouple_file)
+
+            self.log_debug(f"Full r2c command line: {''.join(map(str, cmd))}")
 
             try:
                 subprocess.run(map(str, cmd), capture_output=True, check=True)


### PR DESCRIPTION
The current defaults for the ``srun`` arguments in the SE task make only sense for machines with small to moderate number of cores per node: One node is requested for every MPI rank (i.e. namcouple link). This leads to a waste of resources if there are many cores per node and will even break if there are few (many-core) nodes in the job.