### PR TITLE
Add PALEORCA2 configuration

### DIFF
--- a/rdy2cpl/grids/base/nemo/orca.py
+++ b/rdy2cpl/grids/base/nemo/orca.py
@@ -10,6 +10,7 @@ def _check(subgrid):
 
 
 _orca_names = {
+    (180, 174, 31): "PALEORCA2",
     (180, 148, 31): "ORCA2L31",
     (362, 292, 75): "ORCA1L75",
     (360, 331, 75): "eORCA1L75",


### PR DESCRIPTION
This extends `rdy2cpl` configuration so that it supports also the PALEORCA grid developed by IPSL. 
Briefly, it is a ORCA2 configuration with more regular grid cells, extended to the southpole. 

Further info at: https://gmd.copernicus.org/articles/13/3011/2020/gmd-13-3011-2020.html