### PR TITLE
Add PismGrid base grid type for ice sheet model coupling

### DIFF
--- a/rdy2cpl/grids/base/pism.py
+++ b/rdy2cpl/grids/base/pism.py
@@ -1,0 +1,37 @@
+import numpy as np
+from netCDF4 import Dataset
+
+
+class PismGrid:
+    """PISM rectilinear grid read from a reference NetCDF file.
+
+    Reads 2D lon/lat fields and their corner bounds directly from
+    the file, and computes uniform cell areas from the projected
+    grid spacing (stereographic x/y coordinates).
+    """
+
+    def __init__(self, ref_file, mask_var="land_ice_area_fraction_retreat"):
+        with Dataset(ref_file) as nc:
+            # Transpose from NetCDF (y,x) to Fortran/OASIS (x,y) order
+            self.center_longitudes = nc["lon"][...].data.copy().T
+            self.center_latitudes = nc["lat"][...].data.copy().T
+            self.corner_longitudes = np.transpose(
+                nc["lon_bnds"][...].data.copy(), (1, 0, 2)
+            )
+            self.corner_latitudes = np.transpose(
+                nc["lat_bnds"][...].data.copy(), (1, 0, 2)
+            )
+            x = nc["x"][...].data
+            y = nc["y"][...].data
+            if mask_var and mask_var in nc.variables:
+                self._mask_data = nc[mask_var][...].data.copy().T
+            else:
+                self._mask_data = None
+
+        dx = float(np.abs(np.diff(x)).mean())
+        dy = float(np.abs(np.diff(y)).mean())
+        nx, ny = self.center_longitudes.shape
+        self.shape = (nx, ny)
+        self.size = nx * ny
+        self.areas = np.full((nx, ny), dx * dy)
+        self.mask = np.zeros((nx, ny), dtype="int32")

--- a/rdy2cpl/grids/couple_grid.py
+++ b/rdy2cpl/grids/couple_grid.py
@@ -19,11 +19,13 @@ from rdy2cpl.grids.base.ifs import (
     O1280,
 )
 from rdy2cpl.grids.base.nemo.orca import OrcaTGrid, OrcaUGrid, OrcaVGrid
+from rdy2cpl.grids.base.pism import PismGrid
 from rdy2cpl.grids.base.regular import EquidistantLatLonGrid
 from rdy2cpl.grids.mask_modifiers import (
     invert_mask,
     mask_box,
     oifs_read_mask,
+    pism_read_mask,
     rnfm_read_mask,
 )
 from rdy2cpl.loader import _import_pyoasis
@@ -39,6 +41,7 @@ _base_grids = {
         OrcaTGrid,
         OrcaUGrid,
         OrcaVGrid,
+        PismGrid,
         F128,
         N32,
         N80,
@@ -56,7 +59,8 @@ _base_grids = {
 }
 
 _mask_modifiers = {
-    f.__name__: f for f in (invert_mask, mask_box, oifs_read_mask, rnfm_read_mask)
+    f.__name__: f
+    for f in (invert_mask, mask_box, oifs_read_mask, pism_read_mask, rnfm_read_mask)
 }
 
 _default_model_spec_file = Path(__file__).parent / "model_specs/ecearth.yml"

--- a/rdy2cpl/grids/mask_modifiers.py
+++ b/rdy2cpl/grids/mask_modifiers.py
@@ -40,6 +40,22 @@ def oifs_read_mask(oifs_grid, icmgginit_file="icmgginit"):
     ).reshape(oifs_grid.shape)
 
 
+def pism_read_mask(grid, coverage):
+    """Set mask from PISM ice-area-fraction data stored in the grid object.
+
+    coverage: 'land' masks ice-free points (ice/land-ice points active),
+              'ocean' masks ice-covered points (ice-free points active).
+    """
+    if not hasattr(grid, "_mask_data") or grid._mask_data is None:
+        raise RuntimeError("PismGrid was created without mask data")
+    if coverage == "ocean":
+        grid.mask = np.where(grid._mask_data != 0, 1, 0)
+    elif coverage == "land":
+        grid.mask = np.where(grid._mask_data == 0, 1, 0)
+    else:
+        raise ValueError(f"Unknown PISM mask coverage: {coverage}")
+
+
 def rnfm_read_mask(rnfm_grid, runoff_mapper_file="runoff_maps.nc"):
     """Reads runoff-mapper file and derives mask from drainage basin ids"""
     try:


### PR DESCRIPTION
This PR adds a new base grid type (`PismGrid`) that reads PISM (Parallel Ice Sheet
Model) reference NetCDF files, plus a mask modifier (`pism_read_mask`) for
land/ocean coverage masks. This enables ice sheet model grids to be defined
directly in `ece_couple_grids.yml`. Now ISM grids can be defined in the model
spec YAML like any other component grid. Yay.

Examples:

In `ece_couple_grids.yml`:

```yaml
pism-grtes:
  type:
    name: PismGrid
    args: [grtes_reference_grid.nc]

pism-grtes-land:
  type:
    name: PismGrid
    args: [grtes_reference_grid.nc]
  mask_modifiers:
    - name: pism_read_mask
      kwargs:
        coverage: land

pism-grtes-ocean:
  type:
    name: PismGrid
    args: [grtes_reference_grid.nc]
  mask_modifiers:
    - name: pism_read_mask
      kwargs:
        coverage: ocean
```

The reference file is a standard PISM output/bootstrap/restart file containing
`lon`, `lat`, `lon_bnds`, `lat_bnds`, `x`, `y`, and optionally
`land_ice_area_fraction_retreat` (configurable via the `mask_var` kwarg).