### PR TITLE
Count only active links (fixes #42)

### DIFF
--- a/rdy2cpl/namcouple/types.py
+++ b/rdy2cpl/namcouple/types.py
@@ -80,7 +80,7 @@ class Namcouple:
 
     @property
     def num_links(self):
-        return len(self.links)
+        return sum(link.active for link in self.links)
 
     def reduced(self):
         """Returns the reduced namcouple version, with unique links"""


### PR DESCRIPTION
`Namcouple.num_links` returns number of all links, even non-active. Problem is that when this is used in `Namcouple.__str__()`, it is inconsistent with the actual output of the links in string format, which excludes non-active links.

See issue #42.